### PR TITLE
Make IMPACT-specific configuration changes

### DIFF
--- a/deployment/aws-terraform/1-services/karpenter.tf
+++ b/deployment/aws-terraform/1-services/karpenter.tf
@@ -21,6 +21,10 @@ module "iam_assumable_role_karpenter" {
   oidc_fully_qualified_subjects = ["system:serviceaccount:karpenter:karpenter"]
 }
 
+resource "aws_iam_service_linked_role" "spot" {
+  aws_service_name = "spot.amazonaws.com"
+}
+
 resource "aws_iam_role_policy" "karpenter_controller" {
   name = "karpenter-policy-${local.cluster_name}"
   role = module.iam_assumable_role_karpenter.iam_role_name

--- a/deployment/aws-terraform/application/daskhub/cognito.tf
+++ b/deployment/aws-terraform/application/daskhub/cognito.tf
@@ -33,7 +33,7 @@ resource "aws_cognito_resource_server" "resource" {
 
 resource "aws_cognito_user_pool_client" "client" {
   name = "${local.cluster_name}-client"
-  depends_on = [aws_cognito_identity_provider.provider]
+  # depends_on = [aws_cognito_identity_provider.provider]
 
   generate_secret = true
   user_pool_id = aws_cognito_user_pool.pool.id
@@ -42,22 +42,22 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows = ["code", "implicit"]
   allowed_oauth_scopes = ["email", "openid"]
-  supported_identity_providers = ["COGNITO", "Google"]
+  supported_identity_providers = ["COGNITO"]
 }
 
-resource "aws_cognito_identity_provider" "provider" {
-  user_pool_id = aws_cognito_user_pool.pool.id
-  provider_name = "Google"
-  provider_type = "Google"
+# resource "aws_cognito_identity_provider" "provider" {
+#   user_pool_id = aws_cognito_user_pool.pool.id
+#   provider_name = "Google"
+#   provider_type = "Google"
 
-  provider_details = {
-    authorize_scopes = "email"
-    client_id = var.google_identity_client_id
-    client_secret = var.google_identity_client_secret
-  }
+#   provider_details = {
+#     authorize_scopes = "email"
+#     client_id = var.google_identity_client_id
+#     client_secret = var.google_identity_client_secret
+#   }
 
-  attribute_mapping = {
-    email    = "email"
-    username = "sub"
-  }
-}
+#   attribute_mapping = {
+#     email    = "email"
+#     username = "sub"
+#   }
+# }

--- a/deployment/aws-terraform/application/daskhub/daskhub.tf
+++ b/deployment/aws-terraform/application/daskhub/daskhub.tf
@@ -51,34 +51,39 @@ resource "helm_release" "jupyterhub" {
     value = var.letsencrypt_contact_email
   }
 
+  # set {
+  #   name = "hub.extraEnv.OAUTH_CALLBACK_URL"
+  #   value = "https://${local.jupyter_dns_prefix}.${var.r53_public_hosted_zone}/hub/oauth_callback"
+  # }
+
+  # set {
+  #   name = "hub.extraEnv.OAUTH2_AUTHORIZE_URL"
+  #   value = "https://${local.cognito_domain}/oauth2/authorize"
+  # }
+
+  # set {
+  #   name = "hub.extraEnv.OAUTH2_TOKEN_URL"
+  #   value = "https://${local.cognito_domain}/oauth2/token"
+  # }
+
+  # set {
+  #   name = "hub.extraEnv.OAUTH2_USERDATA_URL"
+  #   value = "https://${local.cognito_domain}/oauth2/userInfo"
+  # }
+
   set {
-    name = "hub.extraEnv.OAUTH_CALLBACK_URL"
+    name = "hub.config.GitHubOAuthenticator.client_id"
+    value = var.github_oauth_client_id
+  }
+
+  set {
+    name = "hub.config.GitHubOAuthenticator.client_secret"
+    value = var.github_oauth_client_secret
+  }
+
+  set {
+    name = "hub.config.GitHubOAuthenticator.oauth_callback_url"
     value = "https://${local.jupyter_dns_prefix}.${var.r53_public_hosted_zone}/hub/oauth_callback"
-  }
-
-  set {
-    name = "hub.extraEnv.OAUTH2_AUTHORIZE_URL"
-    value = "https://${local.cognito_domain}/oauth2/authorize"
-  }
-
-  set {
-    name = "hub.extraEnv.OAUTH2_TOKEN_URL"
-    value = "https://${local.cognito_domain}/oauth2/token"
-  }
-
-  set {
-    name = "hub.extraEnv.OAUTH2_USERDATA_URL"
-    value = "https://${local.cognito_domain}/oauth2/userInfo"
-  }
-
-  set {
-    name = "hub.config.GenericOAuthenticator.client_id"
-    value = aws_cognito_user_pool_client.client.id
-  }
-
-  set {
-    name = "hub.config.GenericOAuthenticator.client_secret"
-    value = aws_cognito_user_pool_client.client.client_secret
   }
 }
 

--- a/deployment/aws-terraform/application/daskhub/variables.tf
+++ b/deployment/aws-terraform/application/daskhub/variables.tf
@@ -18,14 +18,14 @@ variable "auth_domain_prefix" {
   description = "Domain prefix for Cognito OAuth"
 }
 
-variable "google_identity_client_id" {
+variable "github_oauth_client_id" {
   type = string
-  description = "Client ID for Google identity provider"
+  description = "Client ID for Github OAuth"
 }
 
-variable "google_identity_client_secret" {
+variable "github_oauth_client_secret" {
   type = string
-  description = "Client ID for Google identity provider"
+  description = "Client ID for Github OAuth"
 }
 
 variable "jupyter_notebook_s3_bucket" {

--- a/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
+++ b/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
@@ -9,12 +9,12 @@ proxy:
 
 hub:
   config:
-    GenericOAuthenticator:
-      login_service: "AWS Cognito"
-      username_key: "email"
-      userdata_method: "POST"
+    # GenericOAuthenticator:
+    #   login_service: "AWS Cognito"
+    #   username_key: "email"
+    #   userdata_method: "POST"
     JupyterHub:
-      authenticator_class: oauthenticator.generic.GenericOAuthenticator
+      authenticator_class: github
   nodeSelector:
     node-type: core
   image:


### PR DESCRIPTION
This is a set of changes to allow for deployment to a NASA-IMPACT environment.  Primarily, this means using simple Github OAuth to authenticate JupyterHub.  There is also a minor change regarding Karpenter configs which allow for spot instance creation.  It's not clear if this latter commit (c8c597506573f7d561baf67c0d67ac4f1046d352) should be backported to the Azavea master.  It hasn't been needed thus far, but it may have to do with different role configurations.